### PR TITLE
Add support of Statiq virtual directories

### DIFF
--- a/Chocolatey.Docs.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/build.cake
@@ -6,7 +6,7 @@ Setup<BuildData>(context =>
 {
     Information("Setting up BuildData...");
 
-    var buildData = new BuildData(context, BuildParameters.ProjectFilePath, BuildParameters.PublishDirectory, BuildParameters.OutputDirectory);
+    var buildData = new BuildData(context, BuildParameters.ProjectFilePath, BuildParameters.PublishDirectory, BuildParameters.OutputDirectory, BuildParameters.VirtualDirectory);
 
     return buildData;
 });
@@ -64,7 +64,14 @@ BuildParameters.Tasks.StatiqPreviewTask = Task("Statiq-Preview")
       Configuration = buildData.Configuration
     };
 
-    DotNetRun(buildData.ProjectFilePath.FullPath, new ProcessArgumentBuilder().Append(string.Format("preview --output \"{0}\"", buildData.OutputDirectory)), settings);
+    var argumentBuilder = new ProcessArgumentBuilder().Append(string.Format("preview --output \"{0}\"", buildData.OutputDirectory));
+
+    if (buildData.VirtualDirectory != null)
+    {
+        argumentBuilder = argumentBuilder.Append(string.Format(" --virtual-dir \"{0}\"", buildData.VirtualDirectory));
+    }
+
+    DotNetRun(buildData.ProjectFilePath.FullPath, argumentBuilder, settings);
 });
 
 BuildParameters.Tasks.StatiqBuildTask = Task("Statiq-Build")
@@ -154,7 +161,7 @@ BuildParameters.Tasks.PublishDocumentationTask = Task("Publish-Documentation")
 BuildParameters.Tasks.DefaultTask = Task("Default")
     .IsDependentOn("Statiq-Preview");
 
-    ///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 // EXECUTION
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/Chocolatey.Docs.Cake.Recipe/Content/buildData.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/buildData.cake
@@ -6,10 +6,11 @@ public class BuildData
     public FilePath ProjectFilePath { get; set; }
     public DirectoryPath PublishDirectory { get; set; }
     public DirectoryPath OutputDirectory { get; set; }
+    public string VirtualDirectory { get; set; }
     public string Target { get; private set; }
     public string Configuration { get; private set; }
 
-    public BuildData(ICakeContext context, FilePath projectFilePath, DirectoryPath publishDirectory, DirectoryPath outputDirectory)
+    public BuildData(ICakeContext context, FilePath projectFilePath, DirectoryPath publishDirectory, DirectoryPath outputDirectory, string virtualDirectory)
     {
         if (context == null)
         {
@@ -22,6 +23,7 @@ public class BuildData
         ProjectFilePath = projectFilePath;
         PublishDirectory = publishDirectory;
         OutputDirectory = outputDirectory;
+        VirtualDirectory = virtualDirectory;
         Configuration = context.Argument("configuration", "Release");
     }
 }

--- a/Chocolatey.Docs.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/parameters.cake
@@ -3,6 +3,7 @@ public static class BuildParameters
     public static FilePath ProjectFilePath { get; private set; }
     public static DirectoryPath PublishDirectory { get; private set; }
     public static DirectoryPath OutputDirectory { get; private set; }
+    public static string VirtualDirectory { get; private set;}
     public static BuildTasks Tasks { get; set; }
     public static Cake.Core.Configuration.ICakeConfiguration CakeConfiguration { get; private set; }
     public static string Target { get; private set; }
@@ -24,6 +25,7 @@ public static class BuildParameters
         context.Information("ProjectFilePath: {0}", ProjectFilePath);
         context.Information("PublishDirectory: {0}", PublishDirectory);
         context.Information("OutputDirectory: {0}", OutputDirectory);
+        context.Information("VirtualDirectory: {0}", VirtualDirectory);
         context.Information("Target: {0}", Target);
         context.Information("------------------------------------------------------------------------------------------");
     }
@@ -32,7 +34,8 @@ public static class BuildParameters
         ICakeContext context,
         FilePath projectFilePath,
         DirectoryPath publishDirectory = null,
-        DirectoryPath outputDirectory = null)
+        DirectoryPath outputDirectory = null,
+        string virtualDirectory = null)
     {
         if (context == null)
         {
@@ -52,6 +55,7 @@ public static class BuildParameters
         ProjectFilePath = projectFilePath;
         PublishDirectory = publishDirectory;
         OutputDirectory = outputDirectory;
+        VirtualDirectory = virtualDirectory;
         CakeConfiguration = context.GetConfiguration();
         Target = context.Argument("target", "Default");
     }


### PR DESCRIPTION
## Description Of Changes

This PR adds the ability to configure the name of this virtual directory via a build parameter, which can be passed into the SetParameters method in the recipe.cake file.

## Motivation and Context

When testing a Statiq site without a CNAME configured, it is typically run out of a virtual directory, and testing need to be done out of the same named virtual directory.

## Testing

Tested against local instance of docs-recipe-test repository.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Relates to #1 