### PR TITLE
(#12) Remove usage of gulp

### DIFF
--- a/Chocolatey.Docs.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/addins.cake
@@ -4,7 +4,6 @@
 
 #addin nuget:?package=Cake.Git&version=1.0.0
 #addin nuget:?package=Cake.Kudu&version=2.0.0
-#addin nuget:?package=Cake.Gulp&version=2.0.0
 #addin nuget:?package=Cake.Yarn&version=0.4.8
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {

--- a/Chocolatey.Docs.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/build.cake
@@ -47,17 +47,15 @@ BuildParameters.Tasks.YarnInstallTask = Task("Yarn-Install")
     }
 });
 
-BuildParameters.Tasks.RunGulpTask = Task("Run-Gulp")
-    .WithCriteria(() => FileExists("./gulpfile.js"), "gulpfile.js file not found in repository")
+BuildParameters.Tasks.RunChocoThemeTask = Task("Run-Choco-Theme")
     .IsDependentOn("Yarn-Install")
     .Does(() =>
 {
-    Gulp.Local.Execute();
+    Yarn.RunScript("choco-theme");
 });
 
-
 BuildParameters.Tasks.StatiqPreviewTask = Task("Statiq-Preview")
-    .IsDependentOn("Run-Gulp")
+    .IsDependentOn("Run-Choco-Theme")
     .Does<BuildData>((context, buildData) =>
 {
     var settings = new DotNetRunSettings {
@@ -75,7 +73,7 @@ BuildParameters.Tasks.StatiqPreviewTask = Task("Statiq-Preview")
 });
 
 BuildParameters.Tasks.StatiqBuildTask = Task("Statiq-Build")
-    .IsDependentOn("Run-Gulp")
+    .IsDependentOn("Run-Choco-Theme")
     .Does<BuildData>((context, buildData) =>
 {
     var settings = new DotNetRunSettings {
@@ -86,7 +84,7 @@ BuildParameters.Tasks.StatiqBuildTask = Task("Statiq-Build")
 });
 
 BuildParameters.Tasks.StatiqLinkValidationTask = Task("Statiq-LinkValidation")
-    .IsDependentOn("Run-Gulp")
+    .IsDependentOn("Run-Choco-Theme")
     .Does<BuildData>((context, buildData) =>
 {
     var settings = new DotNetRunSettings {

--- a/Chocolatey.Docs.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Docs.Cake.Recipe/Content/tasks.cake
@@ -3,7 +3,7 @@ public class BuildTasks
     // Build Tasks
     public CakeTaskBuilder CleanTask { get; set; }
     public CakeTaskBuilder YarnInstallTask { get; set; }
-    public CakeTaskBuilder RunGulpTask { get; set; }
+    public CakeTaskBuilder RunChocoThemeTask { get; set; }
     public CakeTaskBuilder StatiqPreviewTask { get; set; }
     public CakeTaskBuilder StatiqBuildTask { get; set; }
     public CakeTaskBuilder StatiqLinkValidationTask { get; set; }


### PR DESCRIPTION
## Description Of Changes
This removes the usage of Gulp as it is no longer being used by choco-theme. Instead, choco-theme is now compiled with the RunChocoTheme task which executes a `yarn run choco-theme`.

## Motivation and Context
Gulp is no longer used to compile choco-theme, and has been removed.

## Testing
1. This change is the same change that has been implemented on various repositories using older versions of Cake.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
* #12

Fixes #12
